### PR TITLE
refactor: replace innerHTML with safe renderer

### DIFF
--- a/daily-focus/main.js
+++ b/daily-focus/main.js
@@ -1,3 +1,5 @@
+        import { render } from '../shared/scripts/utils/render.js';
+
         // --- App State ---
         let focusPoints = [];
         let progressState = {};
@@ -45,51 +47,123 @@
             cardElement.className = 'card w-full bg-white p-6 rounded-xl shadow-lg border border-gray-200';
             cardElement.dataset.pointId = pointId;
 
-            const actionsHtml = point.actions.map((action, index) => {
-                const isChecked = progressState[pointId] ? progressState[pointId][index] : false;
-                return `
-                    <li class="action-item rounded-lg ${isChecked ? 'completed' : ''}">
-                        <label for="action-${pointId}-${index}" class="flex items-center p-3 cursor-pointer">
-                            <input id="action-${pointId}-${index}" type="checkbox"
-                                   class="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                   ${isChecked ? 'checked' : ''}
-                                   onchange="handleCheckboxChange(this, '${pointId}', ${index})">
-                            <span class="ml-3 text-gray-700">${action}</span>
-                        </label>
-                    </li>
-                `;
-            }).join('');
+            // Top section
+            const topDiv = document.createElement('div');
+            const headerDiv = document.createElement('div');
+            headerDiv.className = 'flex justify-between items-center mb-3';
 
-            cardElement.innerHTML = `
-                <div>
-                    <div class="flex justify-between items-center mb-3">
-                        <span class="text-sm font-semibold text-indigo-600">${point.category}</span>
-                        <span class="progress-text text-sm font-medium text-gray-500"></span>
-                    </div>
-                    <div class="progress-bar w-full bg-gray-200 rounded-full h-2.5 mb-4">
-                        <div class="progress-bar-inner bg-green-500 h-2.5 rounded-full" style="width: 0%"></div>
-                    </div>
-                    <h3 class="text-lg md:text-xl font-bold text-gray-800">${point.title}</h3>
-                    <p class="text-gray-500 italic my-2 text-sm md:text-base">"${point.quote}"</p>
-                </div>
-                <div>
-                    <p class="font-semibold mb-2 text-gray-700">Action Items:</p>
-                    <ul class="space-y-2">${actionsHtml}</ul>
-                    <div class="completion-banner hidden mt-4 p-4 bg-green-100 border-l-4 border-green-500 rounded-r-lg">
-                        <div class="flex">
-                            <div class="py-1">
-                                <svg class="h-6 w-6 text-green-500 mr-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                            </div>
-                            <div>
-                                <p class="font-bold text-green-800">All Actions Completed!</p>
-                                <p class="text-sm text-green-700">✨ Fantastic work! You've mastered this focus. ✨</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
+            const categorySpan = document.createElement('span');
+            categorySpan.className = 'text-sm font-semibold text-indigo-600';
+            categorySpan.textContent = point.category;
+
+            const progressSpan = document.createElement('span');
+            progressSpan.className = 'progress-text text-sm font-medium text-gray-500';
+
+            headerDiv.appendChild(categorySpan);
+            headerDiv.appendChild(progressSpan);
+
+            const progressBar = document.createElement('div');
+            progressBar.className = 'progress-bar w-full bg-gray-200 rounded-full h-2.5 mb-4';
+            const progressBarInner = document.createElement('div');
+            progressBarInner.className = 'progress-bar-inner bg-green-500 h-2.5 rounded-full';
+            progressBarInner.style.width = '0%';
+            progressBar.appendChild(progressBarInner);
+
+            const title = document.createElement('h3');
+            title.className = 'text-lg md:text-xl font-bold text-gray-800';
+            title.textContent = point.title;
+
+            const quote = document.createElement('p');
+            quote.className = 'text-gray-500 italic my-2 text-sm md:text-base';
+            quote.textContent = `"${point.quote}"`;
+
+            topDiv.appendChild(headerDiv);
+            topDiv.appendChild(progressBar);
+            topDiv.appendChild(title);
+            topDiv.appendChild(quote);
+
+            // Bottom section
+            const bottomDiv = document.createElement('div');
+
+            const actionsLabel = document.createElement('p');
+            actionsLabel.className = 'font-semibold mb-2 text-gray-700';
+            actionsLabel.textContent = 'Action Items:';
+
+            const ul = document.createElement('ul');
+            ul.className = 'space-y-2';
+
+            point.actions.forEach((action, index) => {
+                const isChecked = progressState[pointId] ? progressState[pointId][index] : false;
+
+                const li = document.createElement('li');
+                li.className = `action-item rounded-lg ${isChecked ? 'completed' : ''}`;
+
+                const label = document.createElement('label');
+                label.className = 'flex items-center p-3 cursor-pointer';
+                label.setAttribute('for', `action-${pointId}-${index}`);
+
+                const input = document.createElement('input');
+                input.id = `action-${pointId}-${index}`;
+                input.type = 'checkbox';
+                input.className = 'h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500';
+                if (isChecked) {
+                    input.checked = true;
+                }
+                input.addEventListener('change', () => window.handleCheckboxChange(input, pointId, index));
+
+                const span = document.createElement('span');
+                span.className = 'ml-3 text-gray-700';
+                span.textContent = action;
+
+                label.appendChild(input);
+                label.appendChild(span);
+                li.appendChild(label);
+                ul.appendChild(li);
+            });
+
+            const completionBanner = document.createElement('div');
+            completionBanner.className = 'completion-banner hidden mt-4 p-4 bg-green-100 border-l-4 border-green-500 rounded-r-lg';
+
+            const bannerFlex = document.createElement('div');
+            bannerFlex.className = 'flex';
+
+            const iconWrapper = document.createElement('div');
+            iconWrapper.className = 'py-1';
+            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('class', 'h-6 w-6 text-green-500 mr-4');
+            svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+            svg.setAttribute('fill', 'none');
+            svg.setAttribute('viewBox', '0 0 24 24');
+            svg.setAttribute('stroke', 'currentColor');
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('stroke-linejoin', 'round');
+            path.setAttribute('stroke-width', '2');
+            path.setAttribute('d', 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z');
+            svg.appendChild(path);
+            iconWrapper.appendChild(svg);
+
+            const textWrapper = document.createElement('div');
+            const bannerTitle = document.createElement('p');
+            bannerTitle.className = 'font-bold text-green-800';
+            bannerTitle.textContent = 'All Actions Completed!';
+            const bannerText = document.createElement('p');
+            bannerText.className = 'text-sm text-green-700';
+            bannerText.textContent = "✨ Fantastic work! You've mastered this focus. ✨";
+            textWrapper.appendChild(bannerTitle);
+            textWrapper.appendChild(bannerText);
+
+            bannerFlex.appendChild(iconWrapper);
+            bannerFlex.appendChild(textWrapper);
+            completionBanner.appendChild(bannerFlex);
+
+            bottomDiv.appendChild(actionsLabel);
+            bottomDiv.appendChild(ul);
+            bottomDiv.appendChild(completionBanner);
+
+            cardElement.appendChild(topDiv);
+            cardElement.appendChild(bottomDiv);
+
             return cardElement;
         }
 
@@ -146,8 +220,7 @@
 
             if (dailyPoint) {
                 const card = createCard(dailyPoint);
-                cardOfTheDayContainer.innerHTML = '';
-                cardOfTheDayContainer.appendChild(card);
+                render(cardOfTheDayContainer, card);
                 updateProgressUI(dailyPoint.id);
             }
         }
@@ -161,10 +234,13 @@
         }
 
         function showCardInLibrary(index) {
-            cardContainer.innerHTML = '';
-
             if (!currentDeck || currentDeck.length === 0) {
-                cardContainer.innerHTML = `<div class="text-center text-gray-500 p-8 bg-white rounded-xl shadow-md"><h3>No items in this category.</h3></div>`;
+                const noItemsDiv = document.createElement('div');
+                noItemsDiv.className = 'text-center text-gray-500 p-8 bg-white rounded-xl shadow-md';
+                const h3 = document.createElement('h3');
+                h3.textContent = 'No items in this category.';
+                noItemsDiv.appendChild(h3);
+                render(cardContainer, noItemsDiv);
                 cardNavigation.style.display = 'none';
                 return;
             }
@@ -173,7 +249,7 @@
 
             const point = currentDeck[index];
             const card = createCard(point);
-            cardContainer.appendChild(card);
+            render(cardContainer, card);
             updateProgressUI(point.id);
 
             cardCounter.textContent = `${index + 1} / ${currentDeck.length}`;

--- a/rpo-training/js/app.js
+++ b/rpo-training/js/app.js
@@ -1,4 +1,5 @@
 import { initBackToTop } from '../../shared/scripts/backToTop.js';
+import { render } from '../../shared/scripts/utils/render.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const mainPage = document.getElementById('main-page');
@@ -33,43 +34,62 @@ document.addEventListener('DOMContentLoaded', () => {
         'session-7-1-page': 'Session 7.1: The ROI of AI in Recruiting'
     };
 
-    function showSessionMenu(moduleId) {
-        const moduleNum = moduleId.split('-')[1];
-        const sessions = Object.keys(pageTitles)
-            .filter(key => key.startsWith(`session-${moduleNum}-`))
-            .map(key => ({
-                id: key,
-                title: pageTitles[key]
-            }));
+      function showSessionMenu(moduleId) {
+          const moduleNum = moduleId.split('-')[1];
+          const sessions = Object.keys(pageTitles)
+              .filter(key => key.startsWith(`session-${moduleNum}-`))
+              .map(key => ({
+                  id: key,
+                  title: pageTitles[key]
+              }));
 
-        let menuHtml = `
-            <div class="content-section">
-                <button onclick="navigateTo('main-page')" class="mb-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                    &larr; Back to All Modules
-                </button>
-                <h2 class="google-sans text-3xl font-bold text-gray-800">${moduleTitles[moduleId]}</h2>
-                <p class="mt-2 text-lg text-gray-600">Select a session to begin.</p>
-                <ul class="mt-6 space-y-4">
-        `;
+          const container = document.createElement('div');
+          container.className = 'content-section';
 
-        sessions.forEach(session => {
-            menuHtml += `
-                <li>
-                    <a href="#" onclick="event.preventDefault(); navigateTo('${session.id}')" class="block bg-white p-6 rounded-lg shadow-md hover:bg-gray-50 transition">
-                        <h3 class="google-sans text-xl font-bold text-blue-700">${session.title}</h3>
-                    </a>
-                </li>
-            `;
-        });
+          const backButton = document.createElement('button');
+          backButton.className = 'mb-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500';
+          backButton.textContent = '← Back to All Modules';
+          backButton.addEventListener('click', () => navigateTo('main-page'));
 
-        menuHtml += '</ul></div>';
+          const h2 = document.createElement('h2');
+          h2.className = 'google-sans text-3xl font-bold text-gray-800';
+          h2.textContent = moduleTitles[moduleId];
 
-        sessionContainer.innerHTML = menuHtml;
-        sessionContainer.classList.add('active');
-        mainPage.classList.remove('active');
-        headerTitle.textContent = moduleTitles[moduleId] || 'Select a Session';
-        window.scrollTo(0, 0);
-    }
+          const p = document.createElement('p');
+          p.className = 'mt-2 text-lg text-gray-600';
+          p.textContent = 'Select a session to begin.';
+
+          const ul = document.createElement('ul');
+          ul.className = 'mt-6 space-y-4';
+
+          sessions.forEach(session => {
+              const li = document.createElement('li');
+              const a = document.createElement('a');
+              a.href = '#';
+              a.className = 'block bg-white p-6 rounded-lg shadow-md hover:bg-gray-50 transition';
+              a.addEventListener('click', (e) => {
+                  e.preventDefault();
+                  navigateTo(session.id);
+              });
+              const h3 = document.createElement('h3');
+              h3.className = 'google-sans text-xl font-bold text-blue-700';
+              h3.textContent = session.title;
+              a.appendChild(h3);
+              li.appendChild(a);
+              ul.appendChild(li);
+          });
+
+          container.appendChild(backButton);
+          container.appendChild(h2);
+          container.appendChild(p);
+          container.appendChild(ul);
+
+          render(sessionContainer, container);
+          sessionContainer.classList.add('active');
+          mainPage.classList.remove('active');
+          headerTitle.textContent = moduleTitles[moduleId] || 'Select a Session';
+          window.scrollTo(0, 0);
+      }
 
     function navigateTo(pageId) {
         // Store the scroll position if leaving the main page
@@ -87,8 +107,8 @@ document.addEventListener('DOMContentLoaded', () => {
         sessionContainer.classList.remove('active');
 
         if (pageId === 'main-page') {
-            mainPage.classList.add('active');
-            sessionContainer.innerHTML = '';
+              mainPage.classList.add('active');
+              render(sessionContainer, '');
             // Restore scroll position if returning to the main page
             const savedPosition = sessionStorage.getItem('mainPageScrollPosition');
             if (savedPosition) {
@@ -109,8 +129,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     return response.text();
                 })
                 .then(html => {
-                    sessionContainer.innerHTML = html;
-                    sessionContainer.classList.add('active');
+                      render(sessionContainer, html, { sanitize: true });
+                      sessionContainer.classList.add('active');
                     // Re-attach event listeners for any new buttons in the loaded content if necessary
                     const backButton = sessionContainer.querySelector('button');
                     // Store the current module ID before navigating to a session
@@ -132,9 +152,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 })
                 .catch(error => {
-                    console.error('Error fetching session content:', error);
-                    sessionContainer.innerHTML = '<p class="text-red-500">Error loading content. Please try again later.</p>';
-                    sessionContainer.classList.add('active');
+                      console.error('Error fetching session content:', error);
+                      const p = document.createElement('p');
+                      p.className = 'text-red-500';
+                      p.textContent = 'Error loading content. Please try again later.';
+                      render(sessionContainer, p);
+                      sessionContainer.classList.add('active');
                 });
         }
 

--- a/shared/scripts/utils/render.js
+++ b/shared/scripts/utils/render.js
@@ -1,0 +1,28 @@
+import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.es.js';
+
+/**
+ * Safely render content into a target element.
+ * - If `content` is a string, it will be inserted using `textContent` by default.
+ * - To insert HTML, pass `{ sanitize: true }` which sanitizes the string with DOMPurify.
+ * - If `content` is a Node, it will be appended directly after clearing the target.
+ *
+ * @param {Element} target - Element to receive the content.
+ * @param {string|Node|null} content - Content to render.
+ * @param {Object} [options]
+ * @param {boolean} [options.sanitize=false] - When true, treat string content as HTML and sanitize it.
+ */
+export function render(target, content, { sanitize = false } = {}) {
+  if (!target) return;
+  target.replaceChildren();
+  if (content == null) return;
+
+  if (typeof content === 'string') {
+    if (sanitize) {
+      target.innerHTML = DOMPurify.sanitize(content);
+    } else {
+      target.textContent = content;
+    }
+  } else if (content instanceof Node) {
+    target.appendChild(content);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared render helper using DOMPurify to safely inject strings or nodes
- build daily focus cards and library with DOM APIs and centralized renderer
- rebuild RPO training session menu and loader without innerHTML

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ab012df11883309f5f057e2e8d41db