### PR TITLE
Add ARIA roles and semantic navigation

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -14,7 +14,9 @@
 
 
     <!-- Back To Hub Button -->
-    <a href="../index.html" class="hub-button">Back To Hub</a>
+    <nav>
+        <a href="../index.html" class="hub-button">Back To Hub</a>
+    </nav>
     
     <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24 fade-in">
         

--- a/knowledge-content/index.html
+++ b/knowledge-content/index.html
@@ -14,6 +14,10 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
 
+    <nav>
+        <a href="../index.html" class="hub-button">Back To Hub</a>
+    </nav>
+
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-5xl">
 
         <!-- Header Section -->
@@ -99,8 +103,7 @@
         </main>
     </div>
 
-    <a href="../index.html" class="hub-button">Back To Hub</a>
-<button id="back-to-top" title="Back to top" aria-label="Scroll to top">
+    <button id="back-to-top" title="Back to top" aria-label="Scroll to top">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
         stroke-linecap="round" stroke-linejoin="round">
         <path d="m18 15-6-6-6 6" />

--- a/rpo-training/index.html
+++ b/rpo-training/index.html
@@ -21,7 +21,9 @@
     <header class="bg-white site-header sticky top-0 z-10">
         <div class="max-w-5xl mx-auto px-6 py-4 flex justify-between items-center">
             <h1 id="header-title" class="google-sans text-2xl text-gray-700">RPO AI Acceleration Program</h1>
-            <a href="../index.html" class="hub-button">Back To Hub</a>
+            <nav>
+                <a href="../index.html" class="hub-button">Back To Hub</a>
+            </nav>
         </div>
     </header>
 

--- a/shared/scripts/components/navigation.js
+++ b/shared/scripts/components/navigation.js
@@ -22,6 +22,11 @@ export function initializeNavigation() {
     const closeBtn = qs('[data-mobile-menu-close]', { required: true });
     const menuItems = qsa('[data-mobile-menu-item]', menu);
 
+    // Accessibility attributes
+    openBtn.setAttribute('aria-expanded', 'false');
+    menu.setAttribute('role', 'menu');
+    menuItems.forEach(item => item.setAttribute('role', 'menuitem'));
+
     /**
      * Opens the mobile menu and overlay.
      */
@@ -29,6 +34,7 @@ export function initializeNavigation() {
       menu.classList.add('active');
       overlay.classList.add('active');
       document.body.style.overflow = 'hidden'; // Prevent background scrolling
+      openBtn.setAttribute('aria-expanded', 'true');
     };
 
     /**
@@ -38,10 +44,22 @@ export function initializeNavigation() {
       menu.classList.remove('active');
       overlay.classList.remove('active');
       document.body.style.overflow = ''; // Restore background scrolling
+      openBtn.setAttribute('aria-expanded', 'false');
     };
 
     // Event listeners
     openBtn.addEventListener('click', openMenu);
+    openBtn.addEventListener('keydown', (e) => {
+      if (['Enter', ' '].includes(e.key)) {
+        e.preventDefault();
+        openMenu();
+        menuItems[0]?.focus();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        openMenu();
+        menuItems[0]?.focus();
+      }
+    });
     closeBtn.addEventListener('click', closeMenu);
     overlay.addEventListener('click', closeMenu);
 
@@ -54,6 +72,24 @@ export function initializeNavigation() {
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && menu.classList.contains('active')) {
         closeMenu();
+        openBtn.focus();
+      }
+    });
+
+    menu.addEventListener('keydown', (e) => {
+      const items = Array.from(menuItems);
+      const currentIndex = items.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const nextIndex = (currentIndex + 1) % items.length;
+        items[nextIndex].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prevIndex = (currentIndex - 1 + items.length) % items.length;
+        items[prevIndex].focus();
+      } else if (e.key === 'Escape') {
+        closeMenu();
+        openBtn.focus();
       }
     });
 


### PR DESCRIPTION
## Summary
- Ensure navigation links use semantic `<nav>` elements
- Add ARIA roles and keyboard support to dropdown and mobile nav scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab064eadac8330b4f8505193755070