### PR TITLE
chore: add linting and formatting tooling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+  readonly hook_name="$(basename "$0")"
+  readonly husky_dir="$(dirname "$(dirname "$0")")"
+  debug "starting $hook_name..."
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+
+  sh -e "$husky_dir/$hook_name" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    debug "$hook_name hook exited with code $exitCode (error)"
+  fi
+
+  exit $exitCode
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,24 @@ This repository hosts static web pages and assets used for GBS AI learning resou
   - `shared/scripts/` – JavaScript components and utilities shared across pages
   - `shared/ai-sme-colors.css` – shared color palette and design tokens
 
-## Building and Testing
-No build step is required. To preview the site locally, run a simple web server and open `index.html` in a browser:
+## Development Workflow
+
+Install dependencies once in the project root:
 
 ```bash
-python3 -m http.server
+npm install
 ```
+
+Available scripts:
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start the Vite development server |
+| `npm run build` | Build the site for production |
+| `npm run lint` | Run ESLint on the codebase |
+| `npm run format` | Format files using Prettier |
+
+Pre-commit hooks are managed by [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged); staged files are automatically linted and formatted before each commit.
 
 Automated tests are not yet configured. Running `npm test` will indicate the absence of a test script.
 
@@ -25,4 +37,5 @@ Automated tests are not yet configured. Running `npm test` will indicate the abs
 2. Reuse files under `shared/` instead of duplicating scripts or styles.
 3. Verify changes in a browser and run available checks such as `npm test`.
 4. Use clear commit messages and keep the directory structure tidy.
+
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,18 @@
+const js = require('@eslint/js');
+
+module.exports = [
+  js.configs.recommended,
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...js.environments.browser.globals,
+        ...js.environments.node.globals,
+      },
+    },
+    rules: {},
+  },
+];
+

--- a/package.json
+++ b/package.json
@@ -4,11 +4,29 @@
   "description": "This repository hosts static web pages and assets used for GBS AI learning resources, including workshop materials and a prompt library.",
   "main": ".eleventy.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "eleventy"
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "prepare": "husky install",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.2",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.3.4",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.7"
+  },
+  "lint-staged": {
+    "*.{js,css,md}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- configure ESLint, Prettier, TailwindCSS, Vite, Husky and lint-staged
- add lint, format, build and dev scripts
- document development workflow in README

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0e4e602c8330b9b2bc4e254dfec7