### PR TITLE
refactor: sanitize dynamic HTML rendering

### DIFF
--- a/src/gbs-ai-workshop/index.html
+++ b/src/gbs-ai-workshop/index.html
@@ -1097,6 +1097,7 @@
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getAuth, signInAnonymously, signInWithCustomToken, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, doc, getDoc, addDoc, setDoc, updateDoc, deleteDoc, onSnapshot, collection, query, where, getDocs } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { render } from '../shared/scripts/utils/render.js';
 
         // --- GLOBAL STATE ---
         let db, auth, userId, userPromptsUnsubscribe, appId;
@@ -1442,8 +1443,8 @@
 
             if (!customList) return; // Exit if not on the right page
 
-            customList.innerHTML = '';
-            favoriteList.innerHTML = '';
+            customList.replaceChildren();
+            favoriteList.replaceChildren();
 
             const customPrompts = userLibrary.filter(p => p.type === 'custom');
             const favoritePrompts = userLibrary.filter(p => p.type === 'favorite');
@@ -1481,7 +1482,7 @@
         const promptLibraryEl = document.getElementById('prompt-library');
         function displayPrompts(filter) {
             if (!promptLibraryEl) return;
-            promptLibraryEl.innerHTML = '';
+            promptLibraryEl.replaceChildren();
             const filteredPrompts = (filter === 'All') ? prompts : prompts.filter(p => p.category === filter);
 
             filteredPrompts.forEach(prompt => {
@@ -1511,7 +1512,7 @@
                 `;
             }
 
-            card.innerHTML = `
+            render(card, `
                 <div>
                     <h4 class="font-bold text-lg mb-2 text-[#4A90E2]">${prompt.title}</h4>
                     <p class="text-gray-600 text-sm">${prompt.content}</p>
@@ -1519,7 +1520,7 @@
                 <div class="mt-4 pt-4 border-t border-gray-100 flex justify-end items-center">
                     ${buttonsHtml}
                 </div>
-            `;
+            `, { sanitize: true });
             return card;
         }
 
@@ -1679,7 +1680,7 @@
                             document.getElementById('opportunity-title').textContent = details.title;
                             document.getElementById('opportunity-description').textContent = details.description;
                             const examplesList = document.getElementById('opportunity-examples');
-                            examplesList.innerHTML = '';
+                            examplesList.replaceChildren();
                             details.examples.forEach(ex => {
                                 const li = document.createElement('li');
                                 li.textContent = ex;
@@ -1855,10 +1856,10 @@
                 </div>
             `).join('');
 
-            simulatorContainer.innerHTML = `
+            render(simulatorContainer, `
                 <h3 class="text-2xl font-bold text-center mb-6">Choose a Scenario Category</h3>
                 <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">${categoryHtml}</div>
-            `;
+            `, { sanitize: true });
         }
 
         function loadScenario() {
@@ -1867,12 +1868,12 @@
             const scenario = scenarios[currentScenarioCategory][currentScenarioIndex];
 
             if (!scenario) {
-                simulatorContainer.innerHTML = `
+                render(simulatorContainer, `
                     <p class="text-center text-gray-600 text-xl">You've completed all scenarios in this category!</p>
                     <div class="mt-6 text-center">
                         <button id="backToCategoriesBtn" class="bg-gray-600 text-white font-bold py-2 px-6 rounded-full hover:bg-gray-700 transition-colors">Back to Categories</button>
                     </div>
-                `;
+                `, { sanitize: true });
                 return;
             }
 
@@ -1883,7 +1884,7 @@
                 </div>
             `).join('');
 
-            simulatorContainer.innerHTML = `
+            render(simulatorContainer, `
                  <div class="flex justify-between items-center mb-4">
                     <h3 class="text-2xl font-bold text-[#4A90E2]">${scenario.title}</h3>
                     <button id="backToCategoriesBtn" class="text-sm text-gray-500 hover:text-gray-800">&larr; Back to Categories</button>
@@ -1893,7 +1894,7 @@
                 <div class="mt-6 text-right">
                     <button id="nextScenarioBtn" class="hidden bg-[#4A90E2] text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600 transition-colors">Next Scenario</button>
                 </div>
-            `;
+            `, { sanitize: true });
         }
 
         if (simulatorContainer) {
@@ -1964,15 +1965,15 @@
             caseStudyContent.id = 'case-study-content';
             caseStudyContent.className = 'mt-8';
 
-            caseStudyContainer.innerHTML = '';
+            caseStudyContainer.replaceChildren();
             caseStudyContainer.appendChild(caseStudyTabs);
             caseStudyContainer.appendChild(caseStudyContent);
 
             const categories = Object.keys(caseStudies);
 
-            caseStudyTabs.innerHTML = categories.map((category, index) => `
+            render(caseStudyTabs, categories.map((category, index) => `
                 <button class="case-study-tab ${index === 0 ? 'active' : ''}" data-category="${category}">${category}</button>
-            `).join('');
+            `).join(''), { sanitize: true });
 
             loadCaseStudy(categories[0]);
 
@@ -1999,7 +2000,7 @@
                 ${index < studySteps.length - 1 ? '<div class="timeline-connector"></div>' : ''}
             `).join('');
 
-            caseStudyContent.innerHTML = `<div class="timeline-container">${stepsHtml}</div>`;
+            render(caseStudyContent, `<div class="timeline-container">${stepsHtml}</div>`, { sanitize: true });
         }
 
         // --- "My Day with AI" Logic ---
@@ -2009,13 +2010,13 @@
             if (!myDayContainer) return;
 
             if (index >= myDayEvents.length) {
-                myDayContainer.innerHTML = `
+                render(myDayContainer, `
                     <p class="text-center text-gray-600 text-2xl font-bold">You've completed your day!</p>
                     <p class="text-center text-gray-500 mt-4">You've seen how a few smart prompts can save hours of work. You're ready to start integrating AI into your real workflow.</p>
                     <div class="mt-6 text-center">
                         <button id="restartDayBtn" class="bg-gray-600 text-white font-bold py-2 px-6 rounded-full hover:bg-gray-700 transition-colors">Start Day Over</button>
                     </div>
-                `;
+                `, { sanitize: true });
                 return;
             }
 
@@ -2027,7 +2028,7 @@
                 </div>
             `).join('');
 
-            myDayContainer.innerHTML = `
+            render(myDayContainer, `
                  <div class="mb-4">
                     <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700">${event.time}</span>
                  </div>
@@ -2036,7 +2037,7 @@
                 <div class="mt-6 text-right">
                     <button id="nextDayEventBtn" class="hidden bg-[#4A90E2] text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600 transition-colors">Continue Day &rarr;</button>
                 </div>
-            `;
+            `, { sanitize: true });
         }
 
         if(myDayContainer) {

--- a/src/gbs-prompts/index.njk
+++ b/src/gbs-prompts/index.njk
@@ -146,6 +146,7 @@ nav: true
 
 {% block scripts %}
     <script type="module">
+        import { render } from '../shared/scripts/utils/render.js';
         // --- DATA STRUCTURE ---
         let promptData = {};
         let allPrompts = [];
@@ -261,11 +262,11 @@ nav: true
                 }
             } catch (error) {
                 console.error('Failed to load prompts:', error);
-                categoryCardsContainer.innerHTML = `
+                render(categoryCardsContainer, `
                     <div class="text-center text-red-500">
                         <p>Error loading prompts. Please try again later.</p>
                     </div>
-                `;
+                `, { sanitize: true });
             } finally {
                 loadingIndicator.classList.add('hidden');
                 categoryCardsContainer.classList.remove('hidden');
@@ -346,7 +347,7 @@ nav: true
 
         // --- RENDER FUNCTIONS ---
         function renderHomepage() {
-            categoryCardsContainer.innerHTML = '';
+            categoryCardsContainer.replaceChildren();
             categoryCardsContainer.className = 'grid md:grid-cols-2 lg:grid-cols-3 gap-8';
             for (const categoryName in promptIndex) {
                 const meta = promptIndex[categoryName];
@@ -360,7 +361,7 @@ nav: true
                     `<li><a href="#" class="block py-1.5 text-gray-500" data-category="${categoryName}" data-subcategory="${subName}">→ ${subName}</a></li>`
                 ).join('');
 
-                card.innerHTML = `
+                render(card, `
                     <div class="p-6 text-center">
                         <h2 class="text-xl font-bold main-heading accent-text">${categoryName}</h2>
                         <p class="text-gray-500 text-sm mt-2">${totalPrompts} prompts available</p>
@@ -371,7 +372,7 @@ nav: true
                     <div class="p-6 mt-auto">
                         <button class="see-all-btn w-full py-2.5 rounded-md font-semibold" data-category="${categoryName}">Explore ${categoryName} →</button>
                     </div>
-                `;
+                `, { sanitize: true });
                 categoryCardsContainer.appendChild(card);
             }
         }
@@ -409,7 +410,7 @@ nav: true
 
             promptEl.className = isSearchResult ? 'prompt-block p-4' : 'mb-8';
 
-            promptEl.innerHTML = `
+            render(promptEl, `
                 <div class="flex justify-between items-start mb-3">
                     <div class="flex-1">
                         <div class="badges-container mb-2">
@@ -437,7 +438,7 @@ nav: true
 
                 ${quickStartSection}
                 ${expectedOutputSection}
-            `;
+            `, { sanitize: true });
 
             return promptEl;
         }
@@ -448,9 +449,9 @@ nav: true
          */
         function renderSearchResults(results) {
             const searchTerm = homepageSearchInput.value.trim();
-            categoryCardsContainer.innerHTML = '';
+            categoryCardsContainer.replaceChildren();
             if (results.length === 0) {
-                categoryCardsContainer.innerHTML = `
+                render(categoryCardsContainer, `
                 <div class="text-center text-gray-500 col-span-full py-16">
                     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                         <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2z" />
@@ -462,7 +463,7 @@ nav: true
                             Clear Search
                         </button>
                     </div>
-                </div>`;
+                </div>`, { sanitize: true });
                 return;
             }
 
@@ -475,11 +476,11 @@ nav: true
         }
 
         function renderQuickLinks(activeCategory, activeSubCategory) {
-            quickLinksSidebar.innerHTML = '';
+            quickLinksSidebar.replaceChildren();
             for (const categoryName in promptIndex) {
                 const categoryTitle = document.createElement('h4');
                 categoryTitle.className = 'font-bold mt-4 mb-2 main-heading';
-                categoryTitle.innerHTML = `Gemini Prompts for <span class="accent-text">${categoryName}</span>`;
+                render(categoryTitle, `Gemini Prompts for <span class="accent-text">${categoryName}</span>`, { sanitize: true });
                 quickLinksSidebar.appendChild(categoryTitle);
 
                 const subList = document.createElement('ul');
@@ -506,12 +507,12 @@ nav: true
          * @param {string} activeSubCategory - The sub-category to display.
          */
         function renderDetailView(activeCategory, activeSubCategory) {
-            promptDisplayArea.innerHTML = '';
+            promptDisplayArea.replaceChildren();
             const subCategoryPrompts = promptData[activeCategory][activeSubCategory];
 
             const header = document.createElement('h1');
             header.className = 'text-3xl font-bold mb-8 main-heading';
-            header.innerHTML = `Gemini Prompts for <span class="accent-text">${activeSubCategory}</span>`;
+            render(header, `Gemini Prompts for <span class="accent-text">${activeSubCategory}</span>`, { sanitize: true });
             promptDisplayArea.appendChild(header);
 
             subCategoryPrompts.forEach(prompt => {
@@ -528,11 +529,11 @@ nav: true
          * @param {string} activeCategory - The main category to display.
          */
         function renderAllCategoryView(activeCategory) {
-            promptDisplayArea.innerHTML = '';
+            promptDisplayArea.replaceChildren();
 
             const header = document.createElement('h1');
             header.className = 'text-3xl font-bold mb-8 main-heading';
-            header.innerHTML = `All Prompts in <span class="accent-text">${activeCategory}</span>`;
+            render(header, `All Prompts in <span class="accent-text">${activeCategory}</span>`, { sanitize: true });
             promptDisplayArea.appendChild(header);
 
             const category = promptData[activeCategory];


### PR DESCRIPTION
## Summary
- remove direct innerHTML usage in workshop and prompts pages
- render dynamic content with `render()` helper or DOM APIs to sanitize user data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm install --no-save @eslint/js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4716413c833084d13eb77cf3a88e