### PR TITLE
chore: add eleventy build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ Install dependencies once in the project root:
 npm install
 ```
 
+Eleventy powers the static site build while Vite manages client-side assets.
+
 Available scripts:
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Start the Vite development server |
-| `npm run build` | Build the site for production |
+| `npm run dev` | Serve the site with Eleventy for local development |
+| `npm run build` | Generate pages with Eleventy then bundle assets with Vite |
 | `npm run lint` | Run ESLint on the codebase |
 | `npm run format` | Format files using Prettier |
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "This repository hosts static web pages and assets used for GBS AI learning resources, including workshop materials and a prompt library.",
   "main": ".eleventy.js",
   "scripts": {
-    "dev": "vite",
-    "build": "npm run build:css && vite build",
+    "dev": "eleventy --serve",
+    "build": "eleventy && vite build",
     "build:css": "npx tailwindcss -i ./shared/styles/base.css -o ./shared/styles/tailwind.css --minify",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -17,12 +17,13 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@11ty/eleventy": "^2.0.0",
     "eslint": "^8.57.0",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.7",
     "prettier": "^3.3.2",
     "tailwindcss": "^3.4.4",
-    "vite": "^5.3.4",
-    "husky": "^9.0.11",
-    "lint-staged": "^15.2.7"
+    "vite": "^5.3.4"
   },
   "lint-staged": {
     "*.{js,css,md}": [


### PR DESCRIPTION
## Summary
- add @11ty/eleventy dev dependency
- run Eleventy for dev and build scripts
- document Eleventy + Vite workflow in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@11ty%2feleventy)*
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab4b62cc848330a9f336b4630dc95e