### PR TITLE
test: add unit tests and test scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
@@ -23,7 +24,10 @@
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.2",
     "tailwindcss": "^3.4.4",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "@playwright/test": "^1.46.0",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.6.0"
   },
   "lint-staged": {
     "*.{js,css,md}": [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,10 @@
+// @ts-check
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  testDir: './e2e',
+  use: {
+    headless: true,
+  },
+};
+
+module.exports = config;

--- a/tests/dom-helpers.test.js
+++ b/tests/dom-helpers.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { qs, qsa, getElement } from '../shared/scripts/utils/dom-helpers.js';
+
+describe('qs', () => {
+  it('returns element by selector', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    const el = qs('#app');
+    expect(el).not.toBeNull();
+  });
+
+  it('throws when required and missing', () => {
+    document.body.innerHTML = '';
+    expect(() => qs('#missing', { required: true })).toThrow();
+  });
+});
+
+describe('qsa', () => {
+  it('finds all matching elements', () => {
+    document.body.innerHTML = '<p class="item"></p><p class="item"></p>';
+    const nodes = qsa('.item');
+    expect(nodes.length).toBe(2);
+  });
+});
+
+describe('getElement', () => {
+  it('logs error when element not found', () => {
+    document.body.innerHTML = '';
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = getElement('#missing');
+    expect(el).toBeNull();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Error: Element with selector "#missing" was not found.'));
+    spy.mockRestore();
+  });
+});

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.es.js', () => ({
+  default: { sanitize: vi.fn((html) => `sanitized:${html}`) }
+}), { virtual: true });
+
+import { render } from '../shared/scripts/utils/render.js';
+
+describe('render', () => {
+  it('sets text content for string input', () => {
+    const target = document.createElement('div');
+    render(target, 'hello');
+    expect(target.textContent).toBe('hello');
+  });
+
+  it('sanitizes HTML when sanitize option is true', () => {
+    const target = document.createElement('div');
+    render(target, '<img>', { sanitize: true });
+    expect(target.innerHTML).toBe('sanitized:<img>');
+  });
+
+  it('appends node content', () => {
+    const target = document.createElement('div');
+    const node = document.createElement('span');
+    node.textContent = 'child';
+    render(target, node);
+    expect(target.firstChild).toBe(node);
+  });
+
+  it('returns early when target is null', () => {
+    expect(() => render(null, 'noop')).not.toThrow();
+  });
+});

--- a/vitest.config.cjs
+++ b/vitest.config.cjs
@@ -1,0 +1,7 @@
+const { defineConfig } = require('vitest/config');
+
+module.exports = defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- set up Vitest with jsdom environment for DOM utility testing
- add unit tests for `qs`, `qsa`, `getElement`, and `render`
- include Playwright config for future end-to-end tests

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c526d14833088808c813b7e241c