### PR TITLE
Use local DOMPurify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "dependencies": {
+    "dompurify": "^3.0.2"
+  },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",
     "eslint": "^8.57.0",

--- a/shared/scripts/utils/render.js
+++ b/shared/scripts/utils/render.js
@@ -1,4 +1,4 @@
-import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.es.js';
+import DOMPurify from 'dompurify';
 
 /**
  * Safely render content into a target element.


### PR DESCRIPTION
## Summary
- Replace CDN-based DOMPurify import with npm module.
- Declare DOMPurify as a project dependency so Vite can bundle it.

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: eleventy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e258e488330ad62d7ff09b012c8