### PR TITLE
docs: describe root dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Install dependencies once in the project root:
 npm install
 ```
 
-Eleventy powers the static site build while Vite manages client-side assets.
+Eleventy builds pages from `src` while Vite bundles client-side assets.
+Running `npm run dev` in the project root launches both so every page is served for development.
 
 Available scripts:
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Serve the site with Eleventy for local development |
+| `npm run dev` | Serve all pages with Eleventy and Vite for local development |
 | `npm run build` | Generate pages with Eleventy then bundle assets with Vite |
 | `npm run lint` | Run ESLint on the codebase |
 | `npm run format` | Format files using Prettier |

--- a/src/gbs-ai-workshop/README.md
+++ b/src/gbs-ai-workshop/README.md
@@ -12,13 +12,15 @@ This folder contains the interactive workshop used to introduce GBS teams to pra
   - `../shared/ai-sme-colors.css` – shared color palette
 
 ## Building and Testing
-No build step is necessary. Launch a local server and open `index.html`:
+Run the development server from the repository root to preview this workshop alongside the rest of the site:
 
 ```bash
-python3 -m http.server
+npm run dev
 ```
 
-Automated tests are not defined for this project. Running `npm test` will confirm the absence of tests.
+Eleventy and Vite will serve all pages; open `/gbs-ai-workshop/` in your browser.
+
+Automated tests are not defined for this project. Running `npm test` in the project root will confirm the absence of tests.
 
 ## Contribution Guidelines
 1. Keep markup and styles minimal and reuse files from `../shared/`.

--- a/src/gbs-prompts/README.md
+++ b/src/gbs-prompts/README.md
@@ -10,11 +10,13 @@ This directory contains a simple browser for reusable prompts used during GBS AI
   - `../shared/ai-sme-colors.css` – shared color palette
 
 ## Building and Testing
-The prompt library is a static page. Start a local server and open `index.html` to preview:
+Preview the prompt library using the development server from the repository root:
 
 ```bash
-python3 -m http.server
+npm run dev
 ```
+
+Eleventy and Vite serve all pages, so open `/gbs-prompts/` in your browser.
 
 There are currently no automated tests. Running `npm test` in the repository root will show that no test script is defined.
 


### PR DESCRIPTION
## Summary
- document that the root `npm run dev` command runs both Eleventy and Vite and serves all pages
- guide workshop and prompt library READMEs to use the root dev server for previewing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@11ty%2feleventy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4eeda67483309e00956f05c69c59