### PR TITLE
Configure Vite build for Eleventy output

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eleventy.js",
   "scripts": {
     "dev": "eleventy --serve",
-    "build": "eleventy && vite build",
+    "build": "eleventy && vite build --config vite.config.js",
     "build:css": "npx tailwindcss -i ./shared/styles/base.css -o ./shared/styles/tailwind.css --minify",
     "lint": "eslint --config eslint.config.cjs .",
     "format": "prettier --write .",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+export default defineConfig({
+  root: "dist",         // Eleventy’s output
+  build: { outDir: "dist", emptyOutDir: false }
+});


### PR DESCRIPTION
## Summary
- add Vite configuration targeting Eleventy's `dist` output
- run Vite build via explicit config path in build script

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@11ty%2feleventy)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: eleventy: not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab513b9a9c8330874ec47f930303c0