### PR TITLE
Add roadmap for upcoming modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository hosts static web pages and assets used for GBS AI learning resources, including workshop materials and a prompt library.
 
+## Roadmap
+
+Curious about what's coming next? See the [project roadmap](./roadmap.md) for planned modules and milestones. It is updated quarterly to maintain transparency and momentum.
+
 ## Project Structure
 
 - `index.html` – landing page for the site

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+This project publishes training and resources for GBS AI SMEs. The roadmap lists upcoming modules and milestones.
+
+_Last updated: Q2 2025_
+
+We update this roadmap quarterly to maintain transparency and momentum.
+
+## Q2 2025
+
+- Publish **Model Evaluation** module for the workshop.
+- Add 20 new entries to the **Prompt Library**.
+- Launch a feedback dashboard to visualize site analytics.
+
+## Q3 2025
+
+- Release **AI Governance** module covering risk and compliance.
+- Ship **RPO Training** with hands-on labs.
+- Introduce automated content quality checks in CI.
+
+## Q4 2025
+
+- Expand **Daily Focus** prompts with scenario-based learning.
+- Add localization support for key pages.
+- Conduct comprehensive review and roll over remaining items to 2026 roadmap.


### PR DESCRIPTION
## Summary
- add project roadmap outlining quarterly modules and milestones
- link roadmap from hub README so users can track upcoming work

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abe35790f883308a87ac79be462a0d